### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ will run the installation:
   I've mad an attempt here, but I can't gurantee it's right.
 -->
 ## Downloading the installer
-Download the appropriate version of the installer from the [releases](/releases) page.
+Download the appropriate version of the installer from the [releases](https://github.com/IBM/cpd-cli/releases) page.
 
 
 ## Prerequisites


### PR DESCRIPTION
The current releases link points to https://github.com/IBM/cpd-cli/blob/master/releases which results in a 404 page.